### PR TITLE
Fix rounding issue

### DIFF
--- a/app/code/community/Worldpay/Payments/Model/PaymentMethods/CreditCards.php
+++ b/app/code/community/Worldpay/Payments/Model/PaymentMethods/CreditCards.php
@@ -245,7 +245,7 @@ class Worldpay_Payments_Model_PaymentMethods_CreditCards extends Worldpay_Paymen
             $createOrderRequest = array(
                 'token' => $token,
                 'orderDescription' => $orderDetails['orderDescription'],
-                'amount' => $amount*100,
+                'amount' => intval(round($amount*100)),
                 'currencyCode' => $orderDetails['currencyCode'],
                 'siteCode' => $orderDetails['siteCode'],
                 'name' => $orderDetails['name'],


### PR DESCRIPTION
Fixes a bug present when the amount value has more than two decimal places e.g:

Product with price set to £35.95
Discount of 15% applied, setting the price to 30.5575
Magento rounds this up to £30.56, but this plugin multiplies 30.5575 by 100 to get the pence value without rounding first. This means the 'amount' value is set to 3055.75 and the JSON APi throws an error because the 'amount' isn't an integer.