### PR TITLE
Added missing argument

### DIFF
--- a/app/code/community/Worldpay/Payments/Block/Currency.php
+++ b/app/code/community/Worldpay/Payments/Block/Currency.php
@@ -5,7 +5,7 @@ class Worldpay_Payments_Block_Currency
     public function _toHtml()
     {
         $options = Mage::getSingleton('adminhtml/system_config_source_currency')
-            ->toOptionArray();
+            ->toOptionArray(false);
         foreach ($options as $option) {
             $this->addOption($option['value'], $option['value']);
         }


### PR DESCRIPTION
I have added missing argument, because i have received this error:

> Warning: Missing argument 1 for Mage_Adminhtml_Model_System_Config_Source_Currency::toOptionArray()

The magento method is defined in: 

> app/code/core/Mage/Adminhtml/Model/System/Config/Source/Currency.php on line 32